### PR TITLE
Update Home Assistant integration features

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
 )
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 
 from . import config_flow  # noqa: F401
 from .const import CONTROLLERS, DOMAIN
@@ -54,7 +54,7 @@ async def async_setup(hass, config):
     return True
 
 
-async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Pass conf to all the components."""
 
     controllers = {}
@@ -69,7 +69,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
 
     for device, controller in controllers.items():
         try:
-            await asyncio.wait_for(controller.start(),timeout=10)
+            await asyncio.wait_for(controller.start(), timeout=10)
         except ConnectionAbortedError as connection_aborted_error:
             _LOGGER.error(
                 "Could not connect to device %s: %s",
@@ -80,9 +80,8 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {CONTROLLERS: controllers}
     for component in COMPONENT_TYPES:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
+        coroutine = hass.config_entries.async_forward_entry_setups(entry, [component])
+        hass.async_create_task(coroutine)
 
     return True
 

--- a/__init__.py
+++ b/__init__.py
@@ -79,9 +79,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {CONTROLLERS: controllers}
-    for component in COMPONENT_TYPES:
-        coroutine = hass.config_entries.async_forward_entry_setups(entry, [component])
-        hass.async_create_task(coroutine)
+    await hass.config_entries.async_forward_entry_setups(entry, COMPONENT_TYPES)
 
     return True
 

--- a/__init__.py
+++ b/__init__.py
@@ -84,14 +84,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     return True
 
 
-async def async_unload_entry(hass, config_entry):
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
-    await asyncio.wait(
-        [
-            hass.async_create_task(hass.config_entries.async_forward_entry_unload(config_entry, component))
-            for component in COMPONENT_TYPES
-        ]
-    )
-    hass.data[DOMAIN].pop(config_entry.entry_id)
+    await hass.config_entries.async_unload_platforms(entry, COMPONENT_TYPES)
+    hass.data[DOMAIN].pop(entry.entry_id)
 
     return True

--- a/climate.py
+++ b/climate.py
@@ -13,7 +13,12 @@ from pymadoka import (
 )
 from pymadoka.connection import ConnectionStatus
 
-from homeassistant.components.climate import ClimateEntity, HVACMode, HVACAction, ClimateEntityFeature
+from homeassistant.components.climate import (
+    ClimateEntity,
+    HVACMode,
+    HVACAction,
+    ClimateEntityFeature,
+)
 from homeassistant.components.climate.const import (
     FAN_AUTO,
     FAN_HIGH,
@@ -98,7 +103,12 @@ class DaikinMadokaClimate(ClimateEntity):
     @property
     def supported_features(self):
         """Return the list of supported features."""
-        return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
+        return (
+            ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.FAN_MODE
+            | ClimateEntityFeature.TURN_ON
+            | ClimateEntityFeature.TURN_OFF
+        )
 
     @property
     def available(self):
@@ -369,4 +379,3 @@ class DaikinMadokaClimate(ClimateEntity):
             "sw_version": sw_version,
             "via_device": (DOMAIN, self.unique_id),
         }
-

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Daikin Madoka",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/daikin",
-  "requirements": ["pymadoka==0.2.12"],
+  "requirements": ["pymadoka==0.2.13"],
   "codeowners": ["@mduran80"],
   "iot_class": "local_polling",
   "version" : "1.0.0"


### PR DESCRIPTION
## Summary
- update initialization to use `HomeAssistant` type
- switch to `async_forward_entry_setups`
- add TURN_ON/TURN_OFF features
- minor formatting cleanup

## Testing
- `python -m py_compile __init__.py climate.py config_flow.py sensor.py const.py`

------
https://chatgpt.com/codex/tasks/task_e_68517d34332c8327a56facbe0e7784bb